### PR TITLE
fix #1 - Windows scattered sync read/write incorrectly implemented

### DIFF
--- a/src/std/io/driver/sync.d
+++ b/src/std/io/driver/sync.d
@@ -143,7 +143,12 @@ shared @safe @nogc:
         {
             size_t total;
             foreach (b; bufs)
-                total += read(f, b);
+            {
+                immutable len = read(f, b);
+                total += len;
+                if (len < b.length)
+                    break;
+            }
             return total;
         }
     }
@@ -179,7 +184,12 @@ shared @safe @nogc:
         {
             size_t total;
             foreach (b; bufs)
-                total += write(f, b);
+            {
+                immutable len = write(f, b);
+                total += len;
+                if (len < b.length)
+                    break;
+            }
             return total;
         }
     }

--- a/src/std/io/file.d
+++ b/src/std/io/file.d
@@ -255,6 +255,17 @@ struct File
         assert(f.read(buf[$ / 2 .. $], buf[0 .. $ / 2]) == buf.length);
     }
 
+    @("partial reads")
+    unittest
+    {
+        auto f = File("LICENSE.txt");
+        ubyte[256] buf = void;
+        auto len = f.read(buf[$ / 2 .. $], buf[0 .. $ / 2]);
+        while (len == buf.length)
+            len = f.read(buf[$ / 2 .. $], buf[0 .. $ / 2]);
+        assert(len < buf.length);
+    }
+
     /**
        Write buffer content to file.
 


### PR DESCRIPTION
- must break on short reads/writes so that newly arriving data/buffer-space
  in between read/write calls doesn't lead to gaps in scatter buffers