### PR TITLE
Remove manual File.opAssign

### DIFF
--- a/src/std/io/file.d
+++ b/src/std/io/file.d
@@ -182,15 +182,6 @@ struct File
             close();
     }
 
-    // workaround Issue 18000
-    void opAssign(scope File rhs) scope
-    {
-        auto tmp = f;
-        () @trusted { f = rhs.f; }();
-        rhs.f = tmp;
-        rhs.close();
-    }
-
     /// close the file
     void close() scope @trusted
     {


### PR DESCRIPTION
The bug requiring it was fixed already and the current implementation violated DIP1000 (but was not detected due to another bug...).

---

Blocking dlang/dmd#12260