### PR TITLE
Fix CI setup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,11 +21,14 @@ build: off
 
 test_script:
  - dub test -b unittest-cov --compiler=%DC%
-after_test:
-  - ps: |
-      $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
-      Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
-      bash codecov.sh
+
+# Currently disabled because codecov.sh fails with an exception
+# after_test:
+#   - ps: |
+#       $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
+#       Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+#       bash codecov.sh
+
 branches:
   only:
     - master

--- a/travis.sh
+++ b/travis.sh
@@ -10,7 +10,7 @@ fi
 
 case "${BUILD_TOOL}" in
     meson)
-      pip3 install --user --upgrade pip
+      pip3 install --user --upgrade "pip  < 21.0"
       pip install --user --upgrade meson ninja
       meson builddir -Drun_test=true
       ninja -C builddir test


### PR DESCRIPTION
Fixes the `pip` setup and temporarily disables the CodeCov upload on AppVeyor (IDK what causes the exception in `codecov.sh`).

CC @schveiguy 