### PR TITLE
Fix invalid override for `Throwable.toString`

### DIFF
--- a/src/std/io/net/dns.d
+++ b/src/std/io/net/dns.d
@@ -76,7 +76,7 @@ class DNSException : ErrnoException
     }
 
 protected:
-    override void ioError(scope void delegate(const scope char[]) nothrow @safe sink) const nothrow @trusted
+    override void ioError(scope void delegate(in char[]) nothrow sink) const nothrow
     {
         import core.stdc.string : strlen;
 


### PR DESCRIPTION
The overriding functions assumed stricter qualifiers (`@safe` / `scope`)
for the callback that are not guaranteed by the definition in `Throwable`.

The bug was hidden by [this issue](https://issues.dlang.org/show_bug.cgi?id=21538), see dlang/dmd#13267.

---

Example:

```d
struct Store
{
    const(char)[] buffer;

    void escape(in char[] test) @system
    {
        buffer = test;
    }
}

unittest
{
    IOException ioe = new IOException(String("Test"));
    Throwable t = ioe;

    Store s;
    // ioe.toString(&s.escape); // Rejected by the old signature...
    t.toString(&s.escape);      // .. but still callable via virtual function call
}
```