### PR TITLE
Fix a recent deprecation

### DIFF
--- a/src/std/io/internal/iovec.d
+++ b/src/std/io/internal/iovec.d
@@ -47,7 +47,7 @@ struct TempIOVecs
         _ptr = null;
     }
 
-    @property inout(iovec*) ptr() inout return scope
+    @property inout(iovec*) ptr() inout return
     {
         return _ptr is useStack ? stack.ptr : _ptr;
     }


### PR DESCRIPTION
E.g., with LDC v1.28.1:
```
src/std/io/internal/iovec.d(52): Deprecation: returning `this._ptr is cast(iovec*)18446744073709551615LU ? &this.stack : this._ptr` escapes a reference to parameter `this`
src/std/io/internal/iovec.d(52):        perhaps remove `scope` parameter annotation so `return` applies to `ref`
```