### PR TITLE
Fix deprecation: preview=in

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -14,5 +14,4 @@ configuration "dip1000" {
 }
 configuration "preview_in" {
 	dflags "-preview=in"
-	versions "preview_in"
 }

--- a/dub.sdl
+++ b/dub.sdl
@@ -6,10 +6,13 @@ license "BSL-1.0 (Boost)"
 x:ddoxTool "scod"
 versions "WindowsXP" platform="windows"
 libs "Ws2_32" platform="windows"
-dflags "-preview=in"
 configuration "library" {
 }
 configuration "dip1000" {
        dflags "-dip1000"
        versions "DIP1000"
+}
+configuration "preview_in" {
+	dflags "-preview=in"
+	versions "preview_in"
 }

--- a/dub.sdl
+++ b/dub.sdl
@@ -6,6 +6,7 @@ license "BSL-1.0 (Boost)"
 x:ddoxTool "scod"
 versions "WindowsXP" platform="windows"
 libs "Ws2_32" platform="windows"
+dflags "-preview=in"
 configuration "library" {
 }
 configuration "dip1000" {

--- a/src/std/io/exception.d
+++ b/src/std/io/exception.d
@@ -62,28 +62,14 @@ unittest
     import std.array : Appender;
     Appender!(char[]) buffer;
 
-    void old(const scope char[] line) @safe
-    {
-        buffer.put(line);
-    }
-
-    void new_(in char[] line) @system
+    void bufferSink(in char[] line) @system
     {
         buffer.put(line);
     }
 
     scope e = new IOException(String("Hello, World"));
-    version(preview_in)
-        assert(!__traits(compiles, e.toString(&old)));
-    else
-    {
-        e.toString(&old);
-        assert(buffer[] == "std.io.exception.IOException: Hello, World");
-    }
 
-
-    buffer.clear();
-    e.toString(&new_);
+    e.toString(&bufferSink);
     assert(buffer[] == "std.io.exception.IOException: Hello, World");
 
     buffer.clear();

--- a/src/std/io/exception.d
+++ b/src/std/io/exception.d
@@ -73,8 +73,14 @@ unittest
     }
 
     scope e = new IOException(String("Hello, World"));
-    e.toString(&old);
-    assert(buffer[] == "std.io.exception.IOException: Hello, World");
+    version(preview_in)
+        assert(!__traits(compiles, e.toString(&old)));
+    else
+    {
+        e.toString(&old);
+        assert(buffer[] == "std.io.exception.IOException: Hello, World");
+    }
+
 
     buffer.clear();
     e.toString(&new_);

--- a/src/std/io/internal/string.d
+++ b/src/std/io/internal/string.d
@@ -108,13 +108,15 @@ nothrow pure @safe @nogc:
     }
 
     ///
-    bool opEquals(in ref String s) scope const
+    bool opEquals(scope const ref String s) scope const //REVIEW in String s doesn't work
+                                                        //Error: struct `std.io.internal.string.String` is not copyable because it has a disabled postblit
+                                                        //Is this a bug with the compiler? Is chooses value-param despite postblit being disabled
     {
         return this[] == s[];
     }
 
     ///
-    int opCmp(in ref String s) const
+    int opCmp(scope const ref String s) const
     {
         return __cmp(this[], s[]);
     }

--- a/src/std/io/internal/string.d
+++ b/src/std/io/internal/string.d
@@ -108,9 +108,7 @@ nothrow pure @safe @nogc:
     }
 
     ///
-    bool opEquals(scope const ref String s) scope const //REVIEW in String s doesn't work
-                                                        //Error: struct `std.io.internal.string.String` is not copyable because it has a disabled postblit
-                                                        //Is this a bug with the compiler? Is chooses value-param despite postblit being disabled
+    bool opEquals(scope const ref String s) scope const
     {
         return this[] == s[];
     }

--- a/src/std/io/net/addr.d
+++ b/src/std/io/net/addr.d
@@ -352,7 +352,7 @@ struct SocketAddrIPv4
     }
 
     ///
-    bool opEquals()(in auto ref SocketAddrIPv4 rhs) const @nogc
+    bool opEquals()(in SocketAddrIPv4 rhs) const @nogc //REVIEW "in" should be equivalent to "in auto ref" now, right?
     {
         assert(sa.sin_family == AddrFamily.IPv4);
         assert(rhs.sa.sin_family == AddrFamily.IPv4);
@@ -465,7 +465,7 @@ struct SocketAddrIPv6
     }
 
     ///
-    bool opEquals()(in auto ref SocketAddrIPv6 rhs) const @nogc
+    bool opEquals()(in SocketAddrIPv6 rhs) const @nogc
     {
         assert(sa.sin6_family == AddrFamily.IPv6);
         assert(rhs.sa.sin6_family == AddrFamily.IPv6);
@@ -595,7 +595,7 @@ version (Posix) struct SocketAddrUnix
     }
 
     ///
-    bool opEquals()(in auto ref SocketAddrUnix rhs) const @nogc
+    bool opEquals()(in SocketAddrUnix rhs) const @nogc
     {
         assert(sa.sun_family == AddrFamily.UNIX);
         assert(rhs.sa.sun_family == AddrFamily.UNIX);
@@ -678,7 +678,7 @@ struct SocketAddr
     }
 
     /// Construct generic SocketAddr from specific type `SocketAddrX`.
-    this(SocketAddrX)(in auto ref SocketAddrX addr) pure nothrow @trusted @nogc
+    this(SocketAddrX)(in SocketAddrX addr) pure nothrow @trusted @nogc
             if (isSocketAddr!SocketAddrX)
     {
         import core.stdc.string : memcpy;
@@ -735,7 +735,7 @@ struct SocketAddr
     }
 
     ///
-    bool opEquals(SocketAddrX)(in auto ref SocketAddrX rhs) pure nothrow const @trusted @nogc
+    bool opEquals(SocketAddrX)(in SocketAddrX rhs) pure nothrow const @trusted @nogc
     {
         if (family != rhs.family)
             return false;
@@ -848,9 +848,9 @@ else version (Windows)
 private:
 
 // Won't actually fail with proper buffer size and typed addr, so it'll never set errno and is actually pure
-alias pure_inet_ntop = extern (System) const(char)* function(int, in void*, char*, socklen_t) pure nothrow @nogc;
+alias pure_inet_ntop = extern (System) const(char)* function(int,scope const(void)*, char*, socklen_t) pure nothrow @nogc; //REVIEW in void* = scope const void*?
 // Won't actually fail with proper addr family, so it'll never set errno and is actually pure
-alias pure_inet_pton = extern (System) int function(int, in char*, void*) pure nothrow @nogc;
+alias pure_inet_pton = extern (System) int function(int, scope const(char)*, void*) pure nothrow @nogc;
 
 version (Windows)
 {
@@ -858,7 +858,7 @@ version (Windows)
     extern (Windows) int inet_pton(int, in char*, void*) nothrow @nogc;
 }
 
-const(char)[] ipToString(in ref in_addr addr, return ref char[INET_ADDRSTRLEN] buf) pure nothrow @nogc @trusted
+const(char)[] ipToString(in in_addr addr, return ref char[INET_ADDRSTRLEN] buf) pure nothrow @nogc @trusted
 {
     import core.stdc.string : strlen;
 
@@ -869,7 +869,7 @@ const(char)[] ipToString(in ref in_addr addr, return ref char[INET_ADDRSTRLEN] b
     return p[0 .. strlen(p)];
 }
 
-const(char)[] ipToString(in ref in6_addr addr, return ref char[INET6_ADDRSTRLEN] buf) pure nothrow @nogc @trusted
+const(char)[] ipToString(in in6_addr addr, return ref char[INET6_ADDRSTRLEN] buf) pure nothrow @nogc @trusted
 {
     import core.stdc.string : strlen;
 
@@ -906,7 +906,7 @@ bool stringToIP(S)(S s, ref in6_addr addr) /*pure*/ nothrow @nogc @trusted
     return res == 1;
 }
 
-version (Posix) ubyte SUN_LEN(in ref sockaddr_un sun) pure nothrow @nogc @trusted
+version (Posix) ubyte SUN_LEN(in sockaddr_un sun) pure nothrow @nogc @trusted
 {
     static if (is(typeof(sun.sun_len)))
         return cast(ubyte)(sun.sun_path.offsetof + sun.sun_len);

--- a/src/std/io/net/addr.d
+++ b/src/std/io/net/addr.d
@@ -352,7 +352,7 @@ struct SocketAddrIPv4
     }
 
     ///
-    bool opEquals()(in SocketAddrIPv4 rhs) const @nogc //REVIEW "in" should be equivalent to "in auto ref" now, right?
+    bool opEquals()(in SocketAddrIPv4 rhs) const @nogc
     {
         assert(sa.sin_family == AddrFamily.IPv4);
         assert(rhs.sa.sin_family == AddrFamily.IPv4);
@@ -848,7 +848,7 @@ else version (Windows)
 private:
 
 // Won't actually fail with proper buffer size and typed addr, so it'll never set errno and is actually pure
-alias pure_inet_ntop = extern (System) const(char)* function(int,scope const(void)*, char*, socklen_t) pure nothrow @nogc; //REVIEW in void* = scope const void*?
+alias pure_inet_ntop = extern (System) const(char)* function(int,scope const(void)*, char*, socklen_t) pure nothrow @nogc;
 // Won't actually fail with proper addr family, so it'll never set errno and is actually pure
 alias pure_inet_pton = extern (System) int function(int, scope const(char)*, void*) pure nothrow @nogc;
 

--- a/src/std/io/net/socket.d
+++ b/src/std/io/net/socket.d
@@ -165,7 +165,7 @@ struct Socket
        See_also: http://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
        Throws: `ErrnoException` if binding the socket fails
     */
-    void bind(SocketAddr)(in auto ref SocketAddr addr) @trusted
+    void bind(SocketAddr)(in SocketAddr addr) @trusted
             if (isSocketAddr!SocketAddr)
     {
         driver.bind(s, addr.cargs[]);
@@ -219,7 +219,7 @@ struct Socket
        Params:
          addr = socket address to connect to
     */
-    void connect(SocketAddr)(in auto ref SocketAddr addr) @trusted
+    void connect(SocketAddr)(in SocketAddr addr) @trusted
             if (isSocketAddr!SocketAddr)
     {
         driver.connect(s, addr.cargs[]);

--- a/src/std/io/net/tcp.d
+++ b/src/std/io/net/tcp.d
@@ -88,7 +88,7 @@ struct TCP
          addr = socket address to bind
          backlog = maximum number of pending connections
     */
-    static TCPServer server(SocketAddr)(in auto ref SocketAddr addr, uint backlog = 128)
+    static TCPServer server(SocketAddr)(in SocketAddr addr, uint backlog = 128)
             if (isSocketAddr!SocketAddr)
     {
         auto sock = Socket(addr.family, SocketType.stream, Protocol.default_);
@@ -196,7 +196,7 @@ struct TCP
        Params:
          addr = remote socket address to connect to
      */
-    static TCP client(SocketAddr)(in auto ref SocketAddr addr) @trusted
+    static TCP client(SocketAddr)(in SocketAddr addr) @trusted
             if (isSocketAddr!SocketAddr)
     {
         auto sock = Socket(addr.family, SocketType.stream, Protocol.default_);

--- a/src/std/io/net/udp.d
+++ b/src/std/io/net/udp.d
@@ -98,7 +98,7 @@ struct UDP
        Params:
          addr = socket address to bind
     */
-    static UDP server(SocketAddr)(in auto ref SocketAddr addr)
+    static UDP server(SocketAddr)(in SocketAddr addr)
             if (isSocketAddr!SocketAddr)
     {
         auto res = UDP(addr.family);
@@ -216,7 +216,7 @@ struct UDP
        Params:
          addr = remote socket address to connect to
      */
-    static UDP client(SocketAddr)(in auto ref SocketAddr addr) @trusted
+    static UDP client(SocketAddr)(in SocketAddr addr) @trusted
             if (isSocketAddr!SocketAddr)
     {
         auto res = UDP(addr.family);


### PR DESCRIPTION
Please check lines that contain "REVIEW" in a comment, they need verification and I suspect you can do it faster than me.

Unit tests fail to compile. The offending line looked intentional to me, so I left it in.